### PR TITLE
Verifica ano no numero da art

### DIFF
--- a/analysis/dados-faltantes-por-obra/relatorio-de-ausencia.Rmd
+++ b/analysis/dados-faltantes-por-obra/relatorio-de-ausencia.Rmd
@@ -227,7 +227,7 @@ obras.metricas.relevantes <- tb.dados.municipios %>%
         medicoes_ok_valida = ifelse(total_de_medicoes > 0, medicoes_ok/total_de_medicoes >= 0.8, FALSE) | tempo.de.obra <= 90 | 
             (valor_obra > 10000 & valor_obra <= 150000),
         medicoes_ok_opcional = ifelse(valor_obra > 10000 & valor_obra <= 150000, TRUE, FALSE),
-        numero_art_valido = str_detect(numero_art, paste0("(P|p)(B|b)(",lubridate::year(data_inicio_obra), "|1900)([:digit:]{7})")) | 
+        numero_art_valido = str_detect(numero_art, paste0("(P|p)(B|b)\\s?(201[4-8]|1900)([:digit:]{7})")) | 
             (valor_obra > 10000 & valor_obra <= 30000) | lubridate::year(data_inicio_obra) < 2015,
         numero_art_opcional = ifelse(valor_obra > 10000 & valor_obra <= 30000, TRUE, FALSE),
         num_fotos_medicao_valida = num_fotos_medicao >= total_de_medicoes | (valor_obra > 10000 & valor_obra <= 150000),


### PR DESCRIPTION
Valida também casos em que existe um espaço entre o PB e o número do ART. 
Exemplo: PB 20150026552